### PR TITLE
Fishing Tweaks

### DIFF
--- a/PaliaHook/PaliaOverlay.h
+++ b/PaliaHook/PaliaOverlay.h
@@ -1033,11 +1033,12 @@ public:
 	float NoClipFlySpeed = 600.0f;
 
 	// Fishing Booleans
-	bool bEnableInstantFishing = false;
 	bool bEnableAutoFishing = false;
+	bool bRequireClickFishing = false;
+	bool bEnableInstantFishing = false;
 	bool bPerfectCatch = true;
 	bool bDoInstantSellFish = false;
-	bool bAutoFishing = false;
+	bool bDoDestroyOthers = false;
 
 	// Fishing Numericals
 	float StartRodHealth = 100.0f;


### PR DESCRIPTION
[+] Auto fishing: Automatically casts the fishing rod.
[+] Require holding left click to auto fish option.
[+] Auto destroy items: destroys the item caught. (If Instant Sell is enabled it'll try to sell it first before destroying it.)

[!] Changed sell first from 2 to 5 (why not?)
[!] Changed DurabilityReduction from 100 to 0. (I believe my fishing rod was breaking, idk its late)

~~

Notes:

- Ideally the Auto Destroy Items should NOT destroy fish if Sell Fish is enabled, but it currently does destroy fish if the store component is not available.