### PR TITLE
Potential Crashes Fix & Hide Gathered Ore

### DIFF
--- a/OHook/DetourManager.cpp
+++ b/OHook/DetourManager.cpp
@@ -339,7 +339,9 @@ inline void Func_DoESP(PaliaOverlay* Overlay, const AHUD* HUD) {
         if (ActorType == EType::Animal || ActorType == EType::Bug || ActorType == EType::Players || ActorType == EType::Loot) {
             if (!Actor || !Actor->IsValidLowLevel() || Actor->IsDefaultObject())
                 continue;
-            if (ActorLocation = Actor->K2_GetActorLocation(); ActorLocation.IsZero())
+            if (Actor->RootComponent != nullptr)
+                ActorLocation = Actor->RootComponent->RelativeLocation;
+            if (ActorLocation.IsZero())
                 continue;
             if (Actor == VC)
                 continue;

--- a/OHook/DetourManager.cpp
+++ b/OHook/DetourManager.cpp
@@ -372,8 +372,12 @@ inline void Func_DoESP(PaliaOverlay* Overlay, const AHUD* HUD) {
                 break;
             case EType::Ore:
                 if (Overlay->Ores[Type][Variant]) {
-                    bShouldDraw = true;
-                    Color = Overlay->OreColors[Type];
+                    if (auto Ore = static_cast<ABP_ValeriaGatherableLoot_C*>(Actor)) {
+                        if (Ore->IAmAlive) { //Show Ore only if it has not been gathered by localPlayer
+                            bShouldDraw = true;
+                            Color = Overlay->OreColors[Type];
+                        }
+                    }
                 }
                 break;
             case EType::Players:


### PR DESCRIPTION
It was observed that some GetActorLocation calls ended up causing a crash.
Therefore, substituting for the relative position of the RootComponent is equivalent to obtaining the location of the Actor in the world. A potential fix for the crash issue.

The second change concerns the display of ores in the ESP, hiding them when gathered.
Solution provided by @Diyagi in this issue:
https://github.com/Wimberton/OriginPalia/issues/20

Thanks, @VoidPollo & @Wimberton 